### PR TITLE
Update shared list logic

### DIFF
--- a/src/hooks/use-shared-list.ts
+++ b/src/hooks/use-shared-list.ts
@@ -1,94 +1,387 @@
-'use client'
+"use client";
 
-import { useCallback, useEffect, useState } from 'react'
+import { useState, useEffect, useCallback } from "react";
+import { doc, onSnapshot, setDoc, type Unsubscribe } from "firebase/firestore";
+import { db } from "@/lib/firebase-config";
+import { updateList, type ListData, sanitizeProductArray } from "@/services/firebase-service";
+import { type Product, type Category } from "@/lib/types";
+import { v4 as uuidv4 } from 'uuid';
 import {
-  collection,
-  doc,
-  getDoc,
-  onSnapshot,
-  setDoc,
-  updateDoc,
-  deleteDoc,
-} from 'firebase/firestore'
-import { db } from '../lib/firebase-config'
-import { ListData, Product } from '@/lib/types'
+  categorizeProductAction,
+  correctProductNameAction,
+  handleVoiceCommandAction,
+} from "@/lib/actions";
+import type { Toast } from "@/hooks/use-toast";
 
-export const useSharedList = (listId: string) => {
-  const [sharedListData, setSharedListData] = useState<ListData>({
-    pantry: [],
-    shoppingList: [],
-    history: [],
-  })
+interface ReponToastProps extends Toast {
+    audioText?: string;
+}
+
+type ToastFn = (props: ReponToastProps) => {
+    id: string;
+    dismiss: () => void;
+    update: (props: Toast) => void;
+};
+
+const DEFAULT_LIST_ID = "nuestra-despensa-compartida";
+
+export function useSharedList(listId: string | null, toast: ToastFn) {
+  const finalListId = listId ?? DEFAULT_LIST_ID;
+  const [listData, setListData] = useState<ListData>({ pantry: [], shoppingList: [], history: [] });
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [hasPendingWrites, setHasPendingWrites] = useState(false);
 
   useEffect(() => {
-    if (!listId) return
+    if (!db) {
+      setIsLoaded(true);
+      return;
+    }
+    setIsLoaded(false);
+    const docRef = doc(db, "lists", finalListId);
+    let first = true;
 
-    const sharedListDocRef = doc(collection(db, 'lists'), listId)
-
-    const unsubscribe = onSnapshot(sharedListDocRef, (docSnapshot) => {
-      if (docSnapshot.exists()) {
-        setSharedListData(docSnapshot.data() as ListData)
-      } else {
-        const defaultData: ListData = {
-          pantry: [],
-          shoppingList: [],
-          history: [],
+    const unsubscribe: Unsubscribe = onSnapshot(docRef,
+      (snap) => {
+        setHasPendingWrites(snap.metadata.hasPendingWrites);
+        if (!snap.exists() && first) {
+          setDoc(docRef, { pantry: [], shoppingList: [], history: [] }).catch((error) => {
+            console.error("Failed to create list document:", error);
+            toast({
+              title: "Error de Creación",
+              description: "No se pudo crear la lista compartida.",
+              variant: "destructive",
+            });
+          });
+        } else if (snap.exists()) {
+          const data = snap.data();
+          setListData({
+            pantry: sanitizeProductArray(data.pantry),
+            shoppingList: sanitizeProductArray(data.shoppingList),
+            history: Array.isArray(data.history) ? data.history : [],
+          });
         }
-        setDoc(sharedListDocRef, defaultData)
-        setSharedListData(defaultData)
+        if (first) {
+          setIsLoaded(true);
+          first = false;
+        }
+      },
+      (error) => {
+        console.error("Failed to subscribe to list data:", error);
+        toast({
+          title: "Error de Conexión",
+          description: "No se pudieron cargar los datos. Revisa tu conexión a internet.",
+          variant: "destructive",
+        });
+        setIsLoaded(true);
       }
-    })
+    );
 
-    return () => unsubscribe()
-  }, [listId])
+    return () => unsubscribe();
+  }, [finalListId, toast]);
 
-  const updateRemoteList = useCallback(
-    async (updatedData: Partial<ListData>) => {
-      if (!listId) return
+  const updateRemoteList = useCallback((updatedData: Partial<ListData>) => {
+    if (!db) {
+      toast({
+        title: "Error de Conexión",
+        description: "No se puede conectar a la base de datos. Los cambios no se guardarán.",
+        variant: "destructive",
+        duration: 5000,
+      });
+      return;
+    }
+    updateList(finalListId, updatedData).catch((error) => {
+      console.error("Failed to update list:", error);
+      toast({
+        title: "Error de Sincronización",
+        description: "No se pudieron guardar los cambios.",
+        variant: "destructive",
+      });
+    });
+  }, [finalListId, toast]);
 
-      const sharedListRef = doc(db, 'lists', listId)
+  const handleBulkAdd = useCallback(async (names: string[]) => {
+    if (!db || names.length === 0) return;
 
-      const existingDoc = await getDoc(sharedListRef)
-      if (existingDoc.exists()) {
-        const data = existingDoc.data() as ListData
+    const toastie = toast({ title: `Añadiendo ${names.length} producto(s)...`, duration: 5000 });
 
-        const detectDeletedItems = (
-          original: Product[],
-          updated: Product[]
-        ) => {
-          const updatedIds = new Set(updated.map((p) => p.id))
-          return original.filter((p) => !updatedIds.has(p.id))
+    try {
+      const currentPantryNames = new Set(listData.pantry.map((p) => p.name.toLowerCase()));
+      const shoppingListMap = new Map(listData.shoppingList.map((p) => [p.name.toLowerCase(), p]));
+
+      const itemsToMoveFromShoppingList: Product[] = [];
+      const namesToCreate: string[] = [];
+
+      const correctedNamesMap = new Map<string, string>();
+      for (const name of names) {
+        const { correctedName } = await correctProductNameAction({ productName: name });
+        correctedNamesMap.set(name, correctedName);
+      }
+
+      const uniqueCorrectedNames = [...new Set(correctedNamesMap.values())];
+
+      for (const correctedName of uniqueCorrectedNames) {
+        const lower = correctedName.toLowerCase();
+        if (currentPantryNames.has(lower)) {
+          toast({ title: "¡Ya lo tienes!", description: `"${correctedName}" ya está en tu despensa.` });
+        } else if (shoppingListMap.has(lower)) {
+          itemsToMoveFromShoppingList.push(shoppingListMap.get(lower)!);
+        } else {
+          namesToCreate.push(correctedName);
+        }
+      }
+
+      const newProductsFromScratch = await Promise.all(
+        namesToCreate.map(async (name) => {
+          const { category } = await categorizeProductAction({ productName: name });
+          return {
+            id: uuidv4(),
+            name,
+            category: category as Category,
+            status: "available" as const,
+            isPendingPurchase: false,
+            buyLater: false,
+          };
+        })
+      );
+
+      const finalProductsToAdd = [
+        ...newProductsFromScratch,
+        ...itemsToMoveFromShoppingList.map((p) => {
+          const { reason, ...rest } = p;
+          return { ...rest, status: "available" as const, isPendingPurchase: false, buyLater: false };
+        }),
+      ];
+
+      if (finalProductsToAdd.length > 0) {
+        const newShoppingList = listData.shoppingList.filter(
+          (item) => !itemsToMoveFromShoppingList.some((moved) => moved.id === item.id)
+        );
+        const newPantry = [...listData.pantry, ...finalProductsToAdd];
+        const newHistory = [...new Set([...listData.history, ...finalProductsToAdd.map((p) => p.name)])];
+
+        updateRemoteList({ pantry: newPantry, shoppingList: newShoppingList, history: newHistory });
+
+        const successMessage =
+          finalProductsToAdd.length === 1
+            ? `Se ha añadido "${finalProductsToAdd[0].name}" a tu despensa.`
+            : `Se han añadido ${finalProductsToAdd.length} productos a tu despensa.`;
+
+        toastie.update({ id: toastie.id, title: "¡Añadido!", description: successMessage });
+      } else {
+        toastie.dismiss();
+      }
+    } catch (error) {
+      console.error("Failed to add item(s):", error);
+      toastie.update({
+        id: toastie.id,
+        title: "¡Error!",
+        description: "No se pudieron guardar los productos.",
+        variant: "destructive",
+      });
+    }
+  }, [listData.pantry, listData.shoppingList, listData.history, toast, updateRemoteList, db]);
+
+  const handleAddItem = useCallback(
+    (name: string) => {
+      const productNames = name.split(',').map((n) => n.trim()).filter(Boolean);
+      if (productNames.length > 0) {
+        handleBulkAdd(productNames);
+      }
+    },
+    [handleBulkAdd]
+  );
+
+  const handleBulkAddToShoppingList = useCallback(async (names: string[]) => {
+    if (!db || names.length === 0) return;
+
+    const toastie = toast({ title: `Añadiendo ${names.length} producto(s) a la compra...`, duration: 5000 });
+
+    try {
+      const pantryNames = new Set(listData.pantry.map((p) => p.name.toLowerCase()));
+      const shoppingListNames = new Set(listData.shoppingList.map((p) => p.name.toLowerCase()));
+
+      const productsToCreate: { name: string }[] = [];
+
+      const correctedNames = await Promise.all(names.map((name) => correctProductNameAction({ productName: name })));
+      const uniqueCorrectedNames = [
+        ...new Map(correctedNames.map((item) => [item.correctedName.toLowerCase(), item.correctedName])).values(),
+      ];
+
+      for (const correctedName of uniqueCorrectedNames) {
+        const lower = correctedName.toLowerCase();
+        if (pantryNames.has(lower)) {
+          toast({ title: "¡Ya lo tienes!", description: `"${correctedName}" ya está en tu despensa.` });
+        } else if (shoppingListNames.has(lower)) {
+          toast({ title: "¡Ya anotado!", description: `"${correctedName}" ya está en la lista de la compra.` });
+        } else {
+          productsToCreate.push({ name: correctedName });
+        }
+      }
+
+      if (productsToCreate.length === 0) {
+        toastie.dismiss();
+        return;
+      }
+
+      const newProducts = await Promise.all(
+        productsToCreate.map(async (product) => {
+          const { category } = await categorizeProductAction({ productName: product.name });
+          return {
+            id: uuidv4(),
+            name: product.name,
+            category: category as Category,
+            status: "out of stock" as const,
+            reason: "out of stock" as const,
+            isPendingPurchase: false,
+            buyLater: false,
+          } as Product;
+        })
+      );
+
+      const newShoppingList = [...listData.shoppingList, ...newProducts];
+      const newHistory = [...new Set([...listData.history, ...newProducts.map((p) => p.name)])];
+
+      updateRemoteList({ shoppingList: newShoppingList, history: newHistory });
+
+      const successMessage =
+        newProducts.length === 1
+          ? `Se ha añadido "${newProducts[0].name}" a la lista de la compra.`
+          : `Se han añadido ${newProducts.length} productos a la lista de la compra.`;
+
+      toastie.update({ id: toastie.id, title: "¡Anotado!", description: successMessage });
+    } catch (error) {
+      console.error("Failed to add item(s) to shopping list:", error);
+      toastie.update({
+        id: toastie.id,
+        title: "¡Error!",
+        description: "No se pudieron añadir los productos a la compra.",
+        variant: "destructive",
+      });
+    }
+  }, [listData.pantry, listData.shoppingList, listData.history, toast, updateRemoteList, db]);
+
+  const handleShoppingListAddItem = useCallback(
+    async (name: string) => {
+      const productNames = name.split(',').map((n) => n.trim()).filter(Boolean);
+      if (productNames.length > 0) {
+        await handleBulkAddToShoppingList(productNames);
+      }
+    },
+    [handleBulkAddToShoppingList]
+  );
+
+  const handleVoiceCommand = useCallback(
+    async (command: string) => {
+      if (!command || !db) return;
+
+      try {
+        const pantryNames = listData.pantry.map((p) => p.name);
+        const shoppingListNames = listData.shoppingList.map((p) => p.name);
+
+        const result = await handleVoiceCommandAction({
+          command,
+          pantryList: pantryNames,
+          shoppingList: shoppingListNames,
+        });
+
+        if (!result || result.operations.length === 0) {
+          toast({ title: "Comando de voz", description: result?.response || "No se pudo procesar el comando.", audioText: result?.response });
+          return;
         }
 
-        const deletedFromPantry = updatedData.pantry
-          ? detectDeletedItems(data.pantry, updatedData.pantry)
-          : []
-        const deletedFromShopping = updatedData.shoppingList
-          ? detectDeletedItems(data.shoppingList, updatedData.shoppingList)
-          : []
-        const deletedFromHistory = updatedData.history
-          ? detectDeletedItems(data.history, updatedData.history)
-          : []
+        let newPantry = [...listData.pantry];
+        let newShoppingList = [...listData.shoppingList];
+        let newHistory = [...listData.history];
+        const addedItems = new Set<string>();
 
-        const deletedProducts = [
-          ...deletedFromPantry,
-          ...deletedFromShopping,
-          ...deletedFromHistory,
-        ]
+        const productNamesToCreate = [
+          ...new Set(
+            result.operations.filter((op) => op.action === "add" || op.action === "move").map((op) => op.item)
+          ),
+        ];
 
-        for (const product of deletedProducts) {
-          try {
-            await deleteDoc(doc(db, 'products', product.id))
-          } catch (error) {
-            console.error('❌ Error al eliminar producto de Firestore:', error)
+        const createdProducts = await Promise.all(
+          productNamesToCreate.map(async (name) => {
+            const correctedNameResult = await correctProductNameAction({ productName: name });
+            const { category } = await categorizeProductAction({ productName: correctedNameResult.correctedName });
+            return {
+              id: uuidv4(),
+              name: correctedNameResult.correctedName,
+              category: category as Category,
+              status: "available" as const,
+              isPendingPurchase: false,
+              buyLater: false,
+            } as Product;
+          })
+        );
+
+        const productMap = new Map(createdProducts.map((p) => [p.name.toLowerCase(), p]));
+
+        for (const op of result.operations) {
+          const opItemNameLower = op.item.toLowerCase();
+
+          if (op.action === "add") {
+            const productToAdd = productMap.get(opItemNameLower);
+            if (productToAdd) {
+              if (op.list === "pantry" && !newPantry.some((p) => p.name.toLowerCase() === opItemNameLower)) {
+                newPantry.push({ ...productToAdd, status: "available" });
+                addedItems.add(productToAdd.name);
+              } else if (op.list === "shopping" && !newShoppingList.some((p) => p.name.toLowerCase() === opItemNameLower)) {
+                newShoppingList.push({ ...productToAdd, status: "out of stock", reason: "out of stock" });
+                addedItems.add(productToAdd.name);
+              }
+            }
+          } else if (op.action === "remove") {
+            const inShoppingList = newShoppingList.some((p) => p.name.toLowerCase() === opItemNameLower);
+            if (op.list === "shopping" || (op.list === undefined && inShoppingList)) {
+              newShoppingList = newShoppingList.filter((p) => p.name.toLowerCase() !== opItemNameLower);
+            } else if (op.list === "pantry" || op.list === undefined) {
+              newPantry = newPantry.filter((p) => p.name.toLowerCase() !== opItemNameLower);
+            }
+          } else if (op.action === "move") {
+            const itemInPantry = newPantry.find((p) => p.name.toLowerCase() === opItemNameLower);
+            const itemInShopping = newShoppingList.find((p) => p.name.toLowerCase() === opItemNameLower);
+            const productToMove = itemInPantry || itemInShopping || productMap.get(opItemNameLower);
+
+            if (productToMove) {
+              if (op.from === "pantry" && op.to === "shopping") {
+                newPantry = newPantry.filter((p) => p.name.toLowerCase() !== opItemNameLower);
+                if (!newShoppingList.some((p) => p.name.toLowerCase() === opItemNameLower)) {
+                  newShoppingList.push({ ...productToMove, status: "out of stock", reason: "out of stock" });
+                  addedItems.add(productToMove.name);
+                }
+              } else if (op.from === "shopping" && op.to === "pantry") {
+                newShoppingList = newShoppingList.filter((p) => p.name.toLowerCase() !== opItemNameLower);
+                if (!newPantry.some((p) => p.name.toLowerCase() === opItemNameLower)) {
+                  newPantry.push({ ...productToMove, status: "available" });
+                  addedItems.add(productToMove.name);
+                }
+              }
+            }
           }
         }
+
+        newHistory = [...new Set([...newHistory, ...Array.from(addedItems)])];
+
+        updateRemoteList({ pantry: newPantry, shoppingList: newShoppingList, history: newHistory });
+
+        toast({ title: "¡Entendido!", description: result.response, audioText: result.response });
+      } catch (error) {
+        console.error("Voice command failed:", error);
+        toast({ title: "¡Ups! Algo falló", description: "No pude entender el comando de voz.", variant: "destructive" });
       }
-
-      await updateDoc(sharedListRef, updatedData)
     },
-    [listId]
-  )
+    [listData.pantry, listData.shoppingList, listData.history, updateRemoteList, toast, db]
+  );
 
-  return { ...sharedListData, updateRemoteList }
+  return {
+    ...listData,
+    isLoaded,
+    hasPendingWrites,
+    handleAddItem,
+    handleBulkAdd,
+    updateRemoteList,
+    handleVoiceCommand,
+    handleShoppingListAddItem,
+  };
 }

--- a/src/services/firebase-service.ts
+++ b/src/services/firebase-service.ts
@@ -1,9 +1,7 @@
-
-import { doc, getDoc, setDoc, onSnapshot, type Unsubscribe, updateDoc, arrayUnion } from "firebase/firestore";
+import { doc, getDoc, setDoc, onSnapshot, type Unsubscribe } from "firebase/firestore";
 import { db } from "@/lib/firebase-config";
 import type { Product } from "@/lib/types";
 import { v4 as uuidv4 } from 'uuid';
-
 
 export interface ListData {
   pantry: Product[];
@@ -26,117 +24,40 @@ export const sanitizeProductArray = (products: any): Product[] => {
     const uniqueProducts: Product[] = [];
 
     for (const p of products) {
-        if (p && typeof p === 'object' && p.id != null) { // Check that id is not null/undefined
+        if (p && typeof p === 'object' && p.id != null) {
             if (!seenIds.has(p.id)) {
                 if (p.name && p.category && p.status) {
                     seenIds.add(p.id);
-                    const newProd: Product = {
+                    uniqueProducts.push({
                         id: p.id,
                         name: p.name,
                         category: p.category,
                         status: p.status,
                         isPendingPurchase: p.isPendingPurchase ?? false,
                         buyLater: p.buyLater ?? false,
-                    };
-                    if (newProd.status !== 'available' && p.reason) {
-                        newProd.reason = p.reason;
-                    }
-                    uniqueProducts.push(newProd);
+                        ...(p.reason ? { reason: p.reason } : {}),
+                    });
                 }
-            } else {
-                 console.warn(`Duplicate product ID found and removed during sanitization: ${p.id} (${p.name})`);
             }
-        } else if (p && typeof p === 'object' && !p.id) {
-             console.warn("Product found without an ID, assigning a temporary one. Please check data integrity.", p);
-             const newId = uuidv4();
-             if (!seenIds.has(newId)) {
+        } else if (p && typeof p === 'object' && p.id == null) {
+            const newId = uuidv4();
+            if (!seenIds.has(newId)) {
                 seenIds.add(newId);
-                const newProd: Product = {
+                uniqueProducts.push({
                     id: newId,
                     name: p.name || 'Producto sin nombre',
                     category: p.category || 'Otros',
                     status: p.status || 'available',
                     isPendingPurchase: p.isPendingPurchase ?? false,
                     buyLater: p.buyLater ?? false,
-                };
-                 if (newProd.status !== 'available' && p.reason) {
-                    newProd.reason = p.reason;
-                }
-                uniqueProducts.push(newProd);
-             }
+                    ...(p.reason ? { reason: p.reason } : {}),
+                });
+            }
         }
     }
-    
+
     return uniqueProducts;
 };
-
-
-export async function addProductsToPantry(listId: string, products: Product[], currentPantry: Product[], currentHistory: string[]): Promise<Product[]> {
-  if (!db || products.length === 0) {
-    console.warn("Firebase not initialized or no products to add. Skipping.");
-    return [];
-  }
-
-  const docRef = doc(db, listsCollection, listId);
-
-  try {
-    const currentPantryNames = new Set(currentPantry.map(p => p.name.toLowerCase()));
-    const productsToAdd = products.filter(p => !currentPantryNames.has(p.name.toLowerCase()));
-
-    if (productsToAdd.length === 0) {
-      console.log("All products already exist in the pantry.");
-      return [];
-    }
-
-    const newPantry = [...currentPantry, ...productsToAdd];
-    const newHistory = [...new Set([...currentHistory, ...productsToAdd.map(p => p.name)])];
-    
-    await setDoc(docRef, {
-      pantry: newPantry,
-      history: newHistory,
-    }, { merge: true });
-    
-    return productsToAdd;
-
-  } catch (error) {
-    console.error("Error adding products to pantry:", error);
-    throw error;
-  }
-}
-
-export async function addProductsToShoppingList(listId: string, products: Product[], currentShoppingList: Product[], currentHistory: string[]): Promise<Product[]> {
-  if (!db || products.length === 0) {
-    console.warn("Firebase not initialized or no products to add. Skipping.");
-    return [];
-  }
-
-  const docRef = doc(db, listsCollection, listId);
-
-  try {
-    const currentShoppingListNames = new Set(currentShoppingList.map(p => p.name.toLowerCase()));
-    const productsToAdd = products.filter(p => !currentShoppingListNames.has(p.name.toLowerCase()));
-
-    if (productsToAdd.length === 0) {
-      console.log("All products already exist in the shopping list.");
-      return [];
-    }
-
-    const newShoppingList = [...currentShoppingList, ...productsToAdd];
-    const newHistory = [...new Set([...currentHistory, ...productsToAdd.map(p => p.name)])];
-    
-    await setDoc(docRef, {
-      shoppingList: newShoppingList,
-      history: newHistory,
-    }, { merge: true });
-    
-    return productsToAdd;
-
-  } catch (error) {
-    console.error("Error adding products to shopping list:", error);
-    throw error;
-  }
-}
-
 
 export async function getOrCreateList(listId: string): Promise<ListData> {
   if (!db) {
@@ -149,7 +70,6 @@ export async function getOrCreateList(listId: string): Promise<ListData> {
 
     if (docSnap.exists()) {
       const data = docSnap.data();
-      // Data integrity check and sanitation
       return {
         pantry: sanitizeProductArray(data.pantry),
         shoppingList: sanitizeProductArray(data.shoppingList),
@@ -180,7 +100,6 @@ export async function updateList(listId: string, data: Partial<ListData>): Promi
     await setDoc(docRef, sanitizedData, { merge: true });
   } catch (error) {
     console.error("Error updating list:", error);
-    // Re-throw the error so the calling function can handle it (e.g., show a toast).
     throw error;
   }
 }
@@ -188,13 +107,12 @@ export async function updateList(listId: string, data: Partial<ListData>): Promi
 export function onListUpdate(listId: string, callback: (data: ListData) => void): Unsubscribe {
   if (!db) {
     console.warn("Firebase is not initialized. Listener not attached.");
-    return () => {}; // Return a no-op unsubscribe function
+    return () => {};
   }
   const docRef = doc(db, listsCollection, listId);
-  const unsubscribe = onSnapshot(docRef, (doc) => {
-    if (doc.exists()) {
-      const data = doc.data();
-      // Sanitize data on every update from Firebase.
+  const unsubscribe = onSnapshot(docRef, (docSnap) => {
+    if (docSnap.exists()) {
+      const data = docSnap.data();
       callback({
         pantry: sanitizeProductArray(data.pantry),
         shoppingList: sanitizeProductArray(data.shoppingList),
@@ -210,5 +128,3 @@ export function onListUpdate(listId: string, callback: (data: ListData) => void)
 
   return unsubscribe;
 }
-
-    


### PR DESCRIPTION
## Summary
- update `use-shared-list` to rely on a single Firestore list document and expose helper functions
- simplify Firestore helpers in `firebase-service`

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/uuid')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645a193d448329a4aa2b5c440c8c58