### PR TITLE
Fix duplicate Toast type export

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -192,4 +192,4 @@ function useToast() {
   }
 }
 
-export { useToast, toast, type Toast }
+export { useToast, toast }


### PR DESCRIPTION
## Summary
- remove repeated `Toast` type export

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing `@types/uuid`)*

------
https://chatgpt.com/codex/tasks/task_e_686486c473f483298397ea431b603722