### PR TITLE
Fix dynamic pantry page handler

### DIFF
--- a/src/app/pantry/[listId]/page.tsx
+++ b/src/app/pantry/[listId]/page.tsx
@@ -1,7 +1,12 @@
 import PantryPage from "@/components/pantry-page";
 
-// Making this an async function clarifies to Next.js that it's a Server Component
-// and handles params correctly, fixing the build error.
-export default async function SharedListPage({ params }: { params: { listId: string } }) {
+interface PageProps {
+  params: {
+    listId: string;
+  };
+}
+
+// Dynamic route handler must be async so `params` are available.
+export default async function Page({ params }: PageProps) {
   return <PantryPage listId={params.listId} />;
 }


### PR DESCRIPTION
## Summary
- ensure dynamic route for pantry uses `params` inside an async function

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find types)*

------
https://chatgpt.com/codex/tasks/task_e_6865a05c82208329989d78b534a43d5d