### PR TITLE
Fix pantry dynamic route page

### DIFF
--- a/src/app/pantry/[listId]/page.tsx
+++ b/src/app/pantry/[listId]/page.tsx
@@ -1,12 +1,5 @@
-import PantryPage from "@/components/pantry-page";
+import PantryPage from "e/components/pantry-page";
 
-interface PageProps {
-  params: {
-    listId: string;
-  };
-}
-
-// Dynamic route handler must be async so `params` are available.
-export default async function Page({ params }: PageProps) {
+export default function Page({ params }: { params: { listId: string } }) {
   return <PantryPage listId={params.listId} />;
 }


### PR DESCRIPTION
## Summary
- correct pantry page by removing unnecessary async keyword and using explicit params type

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find type definition file for '@types/uuid')*

------
https://chatgpt.com/codex/tasks/task_e_6865a5be37308329832e6ca10d0083d0