### PR TITLE
Fix PantryPage import

### DIFF
--- a/src/app/pantry/[listId]/page.tsx
+++ b/src/app/pantry/[listId]/page.tsx
@@ -1,4 +1,4 @@
-import PantryPage from "e/components/pantry-page";
+import PantryPage from "@/components/pantry-page";
 
 export default function Page({ params }: { params: { listId: string } }) {
   return <PantryPage listId={params.listId} />;


### PR DESCRIPTION
## Summary
- correct PantryPage import path to use the `@` alias

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6865ae3ac7b48329822eb2c3cbde1eeb