### PR TITLE
Fix isChecking undefined in ShoppingItemCard

### DIFF
--- a/src/components/pantry-page.tsx
+++ b/src/components/pantry-page.tsx
@@ -335,7 +335,8 @@ function ShoppingItemCard({
   onDelete,
   onReturnToPantry,
   onEdit,
-  layoutId
+  layoutId,
+  isChecking = false
 }: {
   item: Product;
   viewMode: ViewMode;
@@ -346,7 +347,7 @@ function ShoppingItemCard({
   onReturnToPantry: (id: string) => void;
   onEdit: (product: Product) => void;
   layoutId: string;
-  isChecking: boolean;
+  isChecking?: boolean;
 }) {
   const cardBorderStyle = {
     available: "border-green-500",


### PR DESCRIPTION
## Summary
- include `isChecking` when destructuring props in `ShoppingItemCard`
- make the prop optional with a default of `false`

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68663b51e4048329af77b7d509ffc990