### PR TITLE
Improve UI color feedback

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,7 +122,7 @@
 [data-state='active'][value='pantry'],
 [data-state='active'][value='shopping-list'],
 [data-state='active'][value='pending'] {
-  box-shadow: inset 0 -3px 0 0;
+  box-shadow: inset 0 -3px 0 0 #3498DB;
 }
 
 [data-state='active'][value='pantry'] {

--- a/src/components/pantry-page.tsx
+++ b/src/components/pantry-page.tsx
@@ -211,9 +211,9 @@ function ProductCard({
   };
 
   const statusStyles = {
-    available: "bg-[#2E8B57] text-white",
-    low: "bg-[#B8860B] text-white",
-    "out of stock": "bg-[#8B0000] text-white",
+    available: "bg-[#27AE60] text-white",
+    low: "bg-[#F39C12] text-white",
+    "out of stock": "bg-[#C0392B] text-white",
   }[product.status];
 
   const isListView = viewMode === 'list';
@@ -246,7 +246,7 @@ function ProductCard({
        <div className={cn("shrink-0", isListView ? "flex items-center gap-1" : "flex flex-wrap justify-center gap-1 mt-2")}>
         {product.status === 'low' && (
           product.isPendingPurchase ? (
-            <div className="flex items-center justify-center text-xs h-8 px-2 rounded-md bg-[#4F6272] text-white border border-[#4F6272] font-medium">
+            <div className="flex items-center justify-center text-xs h-8 px-2 rounded-md bg-[#5D6D7E] text-white border border-[#5D6D7E] font-medium">
                 Pendiente de compra
             </div>
           ) : (
@@ -297,7 +297,7 @@ function ProductCard({
                     </DropdownMenuPortal>
                 </DropdownMenuSub>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem className="text-[#FF4D4D] hover:bg-[#1A1A1A] focus:bg-[#1A1A1A]" onClick={(e) => { e.stopPropagation(); onDelete(product.id); }}>
+                <DropdownMenuItem className="text-[#FF4C4C] hover:bg-[#2C0000] hover:text-white focus:bg-[#2C0000] focus:text-white" onClick={(e) => { e.stopPropagation(); onDelete(product.id); }}>
                     <Trash2 className="mr-2 h-4 w-4" />
                     <span>Eliminar</span>
                 </DropdownMenuItem>
@@ -330,9 +330,9 @@ function ShoppingItemCard({
   isChecking?: boolean;
 }) {
   const statusStyles = {
-    available: "bg-[#2E8B57] text-white",
-    low: "bg-[#B8860B] text-white",
-    "out of stock": "bg-[#8B0000] text-white",
+    available: "bg-[#27AE60] text-white",
+    low: "bg-[#F39C12] text-white",
+    "out of stock": "bg-[#C0392B] text-white",
   }[item.status];
       
   const isListView = viewMode === "list";
@@ -390,7 +390,7 @@ function ShoppingItemCard({
                     </DropdownMenuItem>
                 )}
                 <DropdownMenuSeparator />
-                <DropdownMenuItem className="text-[#FF4D4D] hover:bg-[#1A1A1A] focus:bg-[#1A1A1A]" onClick={() => onDelete(item.id)}>
+                <DropdownMenuItem className="text-[#FF4C4C] hover:bg-[#2C0000] hover:text-white focus:bg-[#2C0000] focus:text-white" onClick={() => onDelete(item.id)}>
                     <Trash2 className="mr-2 h-4 w-4" />
                     <span>Eliminar</span>
                 </DropdownMenuItem>
@@ -640,6 +640,8 @@ export default function PantryPage({ listId }: { listId: string }) {
     let newShoppingList = [...shoppingList];
 
     if (status === 'out of stock') {
+        const interimPantry = pantry.map(p => p.id === id ? { ...p, status: 'out of stock' as ProductStatus } : p);
+        updateRemoteList({ pantry: interimPantry });
         setExitingProductId(id);
         setTimeout(async () => {
             newPantry = pantry.filter(p => p.id !== id);
@@ -1450,7 +1452,7 @@ export default function PantryPage({ listId }: { listId: string }) {
             <Button variant="outline" onClick={() => setConfirmDeleteId(null)}>Cancelar</Button>
             <Button
               variant="destructive"
-              className="bg-[#1A1A1A] text-[#FF4D4D] hover:bg-[#1A1A1A]/90"
+              className="bg-[#2C0000] text-white hover:bg-[#2C0000]/90"
               onClick={() => confirmDeleteId && handleDelete(confirmDeleteId)}
             >
               Eliminar

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-[#5D6D7E]/40 data-[state=checked]:border-transparent data-[state=unchecked]:border-gray-400",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- adjust tab highlight to use bright blue underline
- update product cards with new color palette
- show red flash before moving items to shopping list
- emphasize delete options
- improve visibility of the group switch

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686702fcfe4083299c99a427c70b9941