### PR TITLE
Improve tab styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -167,11 +167,6 @@
   animation: slideRight 0.5s forwards;
 }
 
-.tab-activa {
-  border-bottom: 3px solid #F2DD6C;
-  font-weight: bold;
-  color: #F2DD6C;
-}
 
 @keyframes accordion-down {
   from {

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=active]:tab-activa",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-b-2 border-transparent text-[#AAAAAA] data-[state=active]:bg-primary/50 data-[state=active]:text-white data-[state=active]:border-b-4 data-[state=active]:border-[#4DA6FF]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- update tab trigger styling for a clearer active/inactive state
- remove unused `tab-activa` rule from global CSS

## Testing
- `npm run lint` *(fails: interactive setup)*
- `npm run typecheck`
- `npm ci`

------
https://chatgpt.com/codex/tasks/task_e_68672a0e9cd083298a1a1c4a1c4c3c48