### PR TITLE
Fix dynamic params usage in pantry route

### DIFF
--- a/src/app/pantry/[listId]/page.tsx
+++ b/src/app/pantry/[listId]/page.tsx
@@ -1,5 +1,12 @@
 import PantryPage from "@/components/pantry-page";
 
-export default function Page({ params }: { params: { listId: string } }) {
-  return <PantryPage listId={params.listId} />;
+// `params` is asynchronous in Next.js app router. Await it before using any
+// of its properties to avoid runtime errors.
+export default async function Page({
+  params,
+}: {
+  params: { listId: string };
+}) {
+  const { listId } = await params;
+  return <PantryPage listId={listId} />;
 }


### PR DESCRIPTION
## Summary
- await dynamic `params` before using `listId` in pantry route

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686968e0fd9c832986b22eafdf7d85a6