### PR TITLE
Fix share button copy behavior

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { AuthProvider } from '@/providers/auth-provider';
+import { Toaster } from '@/components/ui/toaster';
 
 
 export const metadata: Metadata = {
@@ -38,6 +39,7 @@ export default function RootLayout({
       <body className="font-body antialiased bg-gray-900 text-white">
         <AuthProvider>
           <main>{children}</main>
+          <Toaster />
         </AuthProvider>
       </body>
     </html>

--- a/src/components/pantry-page.tsx
+++ b/src/components/pantry-page.tsx
@@ -950,14 +950,24 @@ export default function PantryPage({ listId }: { listId: string }) {
   const sortedShoppingListLaterCategories = useMemo(() => groupedShoppingListLater ? Object.keys(groupedShoppingListLater).sort() : [], [groupedShoppingListLater]);
 
   const handleShareLink = () => {
-    navigator.clipboard.writeText(window.location.href).then(
+    const appBaseUrl =
+      window.location.hostname === "localhost"
+        ? "https://repon-demo.web.app"
+        : window.location.origin;
+    const fullLink = `${appBaseUrl}/pantry/nuestra-despensa-compartida`;
+
+    navigator.clipboard.writeText(fullLink).then(
       () => {
-        alert("✅ Enlace copiado al portapapeles");
+        toast({ title: "Enlace copiado al portapapeles", duration: 2500 });
       },
       () => {
-        alert(
-          "No se pudo copiar el enlace. Copia la URL manualmente."
-        );
+        toast({
+          title: "No se pudo copiar el enlace",
+          description:
+            "Esta función podría no estar disponible en tu navegador. Intenta copiar la URL manualmente.",
+          duration: 5000,
+          variant: "destructive",
+        });
       }
     );
   };

--- a/src/components/share-dialog.tsx
+++ b/src/components/share-dialog.tsx
@@ -8,7 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { useReponToast } from "@/hooks/use-repon-toast";
 import type { Product } from "@/lib/types";
-import { Share2, Copy } from "lucide-react";
+import { Copy } from "lucide-react";
 
 interface ShareDialogProps {
   open: boolean;
@@ -56,24 +56,26 @@ export function ShareDialog({ open, onOpenChange, pantry, shoppingList }: ShareD
     return text.trim();
   };
 
-  const generateSummaryText = () => {
-    return `\uD83D\uDED2 Lista RePon:\n - Despensa (${pantry.length})\n - Lista de Compra (${shoppingList.length})`;
-  };
-
   const copyToClipboard = (text: string) => {
     if (!text) {
-      alert(
-        "Nada que copiar. Selecciona al menos una lista con productos."
-      );
+      toast({
+        title: "Nada que copiar",
+        description: "Selecciona al menos una lista con productos.",
+        variant: "destructive",
+        duration: 3000,
+      });
       return;
     }
     navigator.clipboard.writeText(text).then(
       () => {
-        alert("✅ Copiado al portapapeles");
+        toast({ title: "Contenido copiado al portapapeles", duration: 2500 });
         onOpenChange(false);
       },
       () => {
-        alert("Error al copiar el contenido.");
+        toast({
+          title: "Error al copiar el contenido",
+          variant: "destructive",
+        });
       }
     );
   };
@@ -82,7 +84,7 @@ export function ShareDialog({ open, onOpenChange, pantry, shoppingList }: ShareD
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Compartir o Copiar Listas</DialogTitle>
+          <DialogTitle>Compartir lista</DialogTitle>
           <DialogDescription>
             Elige qué listas quieres incluir y cómo quieres compartirlas.
           </DialogDescription>
@@ -100,9 +102,6 @@ export function ShareDialog({ open, onOpenChange, pantry, shoppingList }: ShareD
         <DialogFooter className="sm:justify-end gap-2">
           <Button variant="outline" onClick={() => copyToClipboard(generateShareableText())}>
             <Copy className="mr-2 h-4 w-4" /> Copiar al portapapeles
-          </Button>
-          <Button onClick={() => copyToClipboard(generateSummaryText())}>
-            <Share2 className="mr-2 h-4 w-4" /> Copiar resumen
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/hooks/use-repon-toast.ts
+++ b/src/hooks/use-repon-toast.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Toast } from "@/hooks/use-toast";
+import { toast as baseToast } from "@/hooks/use-toast";
 import { useCallback } from "react";
 
 interface ReponToastProps extends Toast {
@@ -8,8 +9,14 @@ interface ReponToastProps extends Toast {
 }
 
 export function useReponToast() {
-    const toast = useCallback((_props: ReponToastProps) => {
-        return { id: '', dismiss: () => {}, update: (_p: Toast) => {} };
+    const toast = useCallback((props: ReponToastProps) => {
+        const { audioText, ...toastProps } = props;
+        const result = baseToast(toastProps);
+        return {
+            id: result.id,
+            dismiss: result.dismiss,
+            update: (p: Toast) => result.update({ ...p, id: result.id }),
+        };
     }, []);
 
     return { toast };


### PR DESCRIPTION
## Summary
- show toast messages when copying share link or list content
- remove summary copy option and adjust share dialog title
- ensure shared link points to correct base URL
- provide toast provider in main layout

## Testing
- `npm run lint` *(fails: prompts interactive message)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686977d65dec8329884df572d2d7c23b