### PR TITLE
Use dynamic app base URL

### DIFF
--- a/src/components/pantry-page.tsx
+++ b/src/components/pantry-page.tsx
@@ -950,10 +950,7 @@ export default function PantryPage({ listId }: { listId: string }) {
   const sortedShoppingListLaterCategories = useMemo(() => groupedShoppingListLater ? Object.keys(groupedShoppingListLater).sort() : [], [groupedShoppingListLater]);
 
   const handleShareLink = () => {
-    const appBaseUrl =
-      window.location.hostname === "localhost"
-        ? "https://repon-demo.web.app"
-        : window.location.origin;
+    const appBaseUrl = window.location.origin;
     const fullLink = `${appBaseUrl}/pantry/nuestra-despensa-compartida`;
 
     navigator.clipboard.writeText(fullLink).then(


### PR DESCRIPTION
## Summary
- replace temporary app base URL with `window.location.origin`

## Testing
- `npm run lint` *(fails: ESLint config prompt)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68697b8e1ae08329abf173732a89ea51