### PR TITLE
Remove static export from Next.js configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,6 @@ import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
-  output: 'export',
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary
- remove `output: 'export'` to allow dynamic rendering on Firebase Hosting

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: `next export` removed)*

------
https://chatgpt.com/codex/tasks/task_e_68699515ad088329925514209c6a31a7