### PR TITLE
Expose Firebase app globally

### DIFF
--- a/src/lib/firebase-config.ts
+++ b/src/lib/firebase-config.ts
@@ -48,3 +48,7 @@ if (typeof window !== 'undefined' && !(window as any).__firebase_persistence_ena
 }
 
 export { db, auth };
+
+if (typeof window !== 'undefined') {
+  (window as any).__FIREBASE_APP__ = app;
+}


### PR DESCRIPTION
## Summary
- expose Firebase app on the `window` object for debugging

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_686a12f626348329a3ec6500be3baae7