### PR TITLE
Configure Firebase env vars for hosting

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -7,3 +7,6 @@ runConfig:
   # Increase this value if you'd like to automatically spin up
   # more instances in response to increased traffic.
   maxInstances: 1
+  environmentVariables:
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: "apprepon.web.app"
+    NEXT_PUBLIC_FIREBASE_API_KEY: "AIzaSyA66O2Gjf2lyUqh6lx1cUK-GAzwNJ-VU1g"


### PR DESCRIPTION
## Summary
- add `environmentVariables` section under `runConfig` in `apphosting.yaml`

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck`
- `firebase deploy --only hosting` *(fails: No active project / network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686a1bd1eef08329b4ec2846c6ca0c5a