### PR TITLE
Set Next.js output to standalone

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  output: 'standalone',
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary
- update Next.js config to use `output: 'standalone'`

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: Firebase auth error)*

------
https://chatgpt.com/codex/tasks/task_e_686b998fdc1c832999ee88c8dca826b5