### PR TITLE
Fix logo with unoptimized images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
## Summary
- disable next/image optimization so static export works correctly

## Testing
- `npm run build` *(fails: FirebaseError invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_686bb29d45388329ae50e68d6bd077e5