### PR TITLE
Enable static export for Firebase Hosting

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "apprepon"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ node_modules/
 dist/
 .cache/
 *.log
-/
+out/
+.firebase/

--- a/README.md
+++ b/README.md
@@ -95,10 +95,18 @@ Selecciona:
 - **Hosting:** para desplegar
 - **Functions:** si quieres desplegar también IA en cloud (opcional)
 
-4. **Lanza el despliegue:**
+4. **Genera la versión estática:**
 
 ```bash
-firebase deploy
+npm run build
+```
+
+Esto creará la carpeta `out/` y copiará su contenido a `.firebase/apprepon/hosting/`.
+
+5. **Lanza el despliegue:**
+
+```bash
+firebase deploy --only hosting
 ```
 
 La aplicación quedará disponible en tu dominio Firebase o personalizado si lo configuras.

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
-  output: 'standalone',
+  output: 'export',
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
-    "build": "next build && next export",
+      "build": "next build && npm run postbuild",
+      "postbuild": "node scripts/postbuild.js",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,21 @@
+const { cp, mkdir, access } = require('fs/promises');
+const { join } = require('path');
+
+async function main() {
+  const outDir = join(process.cwd(), 'out');
+  try {
+    await access(outDir);
+  } catch {
+    console.error('Build output not found:', outDir);
+    return;
+  }
+
+  const destDir = join(process.cwd(), '.firebase', 'apprepon', 'hosting');
+  await mkdir(destDir, { recursive: true });
+  await cp(outDir, destDir, { recursive: true });
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- configure Next.js to use `output: 'export'`
- update build scripts and add postbuild copying
- ignore build and Firebase directories
- document static build and deployment instructions
- add Firebase project configuration

## Testing
- `node scripts/postbuild.js` *(fails: Build output not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbb5eca948329b55be07360a20613