### PR TITLE
Fix pantry route params handling

### DIFF
--- a/src/app/pantry/[listId]/page.tsx
+++ b/src/app/pantry/[listId]/page.tsx
@@ -7,6 +7,6 @@ export default async function Page({
 }: {
   params: { listId: string };
 }) {
-  const { listId } = await params;
+  const { listId } = params;
   return <PantryPage listId={listId} />;
 }


### PR DESCRIPTION
## Summary
- remove incorrect `await` when reading `params.listId` in pantry page

## Testing
- `npm install` *(install deps)*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_686bd108c71c8329a9edd55e325a4ec9