### PR TITLE
Add safeguards against accidental list wiping

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,9 +3,17 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Temporarily allow public read and write access to the 'lists' collection.
+    // Public reads are allowed, but writes are restricted.
     match /lists/{listId} {
-      allow read, write: if true;
+      allow read: if true;
+      allow write: if
+        // Allow clearing explicitly when forceClear flag is provided
+        (request.resource.data.forceClear == true) ||
+        // Otherwise, prevent overwriting with empty arrays
+        (
+          (!("pantry" in request.resource.data) || request.resource.data.pantry.size() > 0) &&
+          (!("shoppingList" in request.resource.data) || request.resource.data.shoppingList.size() > 0)
+        );
     }
   }
 }


### PR DESCRIPTION
## Summary
- block writes that clear lists unless `forceClear` flag is present
- stop silently creating empty list documents
- backup the current list before every update and use `updateDoc` for existing docs
- expose a `clearPantry` helper in `useSharedList`

## Testing
- `npm run lint` *(fails: `next` command not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/uuid')*

------
https://chatgpt.com/codex/tasks/task_e_686bf5662a0483298869902f33d2f00c