### PR TITLE
Default grouped view for pantry

### DIFF
--- a/src/components/pantry-page.tsx
+++ b/src/components/pantry-page.tsx
@@ -404,7 +404,7 @@ export default function PantryPage({ listId }: { listId: string }) {
   const { pantry, shoppingList, history, isLoaded, hasPendingWrites, handleAddItem, handleBulkAdd, updateRemoteList, handleShoppingListAddItem } = useSharedList(listId, toast);
   
   const [viewMode, setViewMode] = useState<ViewMode>("list");
-  const [groupByCategory, setGroupByCategory] = useState(false);
+  const [groupByCategory, setGroupByCategory] = useState(true);
   const [sortConfig, setSortConfig] = useState<SortConfig>({ by: 'name', order: 'asc' });
   const [statusFilter, setStatusFilter] = useState<'all' | ProductStatus>('all');
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- default pantry screen to grouped list view

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_686c15203fa4832997829683ddb773a4