### PR TITLE
Fix sync indicator persistence

### DIFF
--- a/src/hooks/use-shared-list.ts
+++ b/src/hooks/use-shared-list.ts
@@ -39,7 +39,9 @@ export function useSharedList(listId: string | null, toast: ToastFn) {
     const docRef = doc(db, "lists", finalListId);
     let first = true;
 
-    const unsubscribe: Unsubscribe = onSnapshot(docRef,
+    const unsubscribe: Unsubscribe = onSnapshot(
+      docRef,
+      { includeMetadataChanges: true },
       (snap) => {
         setHasPendingWrites(snap.metadata.hasPendingWrites);
         if (snap.exists()) {

--- a/src/services/firebase-service.ts
+++ b/src/services/firebase-service.ts
@@ -149,7 +149,10 @@ export function onListUpdate(listId: string, callback: (data: ListData) => void)
     return () => {};
   }
   const docRef = doc(db, listsCollection, listId);
-  const unsubscribe = onSnapshot(docRef, (docSnap) => {
+  const unsubscribe = onSnapshot(
+    docRef,
+    { includeMetadataChanges: true },
+    (docSnap) => {
     if (docSnap.exists()) {
       const data = docSnap.data();
       callback({


### PR DESCRIPTION
## Summary
- track metadata changes in Firestore listeners so hasPendingWrites updates

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find type definition file for '@types/uuid')*

------
https://chatgpt.com/codex/tasks/task_e_686c19ad633483299ed73fbd11629089