### PR TITLE
Implement category learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ RePon es una aplicación web pensada para ayudarte a organizar la despensa y la 
 ## Funciones de IA
 - **Corrección ortográfica** y capitalización de los nombres introducidos.
 - **Sugerencia automática de categoría** para cada nuevo producto.
+- **Aprendizaje de categorías**: si cambias la categoría manualmente, la app la recordará para futuras ocasiones.
 - **Identificación de productos en una foto** para añadirlos en bloque.
 - **Generación de mensajes gramaticales** y notificaciones.
 - **Creación de recetas** basadas en lo que está disponible en la despensa.

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -12,6 +12,11 @@ import {
   type RefineCategoryOutput,
 } from "@/ai/flows/refine-category";
 import {
+  improveCategorization,
+  type ImproveCategorizationInput,
+  type ImproveCategorizationOutput,
+} from "@/ai/flows/improve-categorization";
+import {
   handleVoiceCommand,
   type VoiceCommandInput,
   type VoiceCommandOutput,
@@ -76,6 +81,13 @@ export async function refineCategoryAction(
 ): Promise<RefineCategoryOutput> {
   const fallback = { refinedCategory: input.userOverrideCategory };
   return runWithAIFallback(refineCategory, input, fallback, 'refineCategory');
+}
+
+export async function improveCategorizationAction(
+  input: ImproveCategorizationInput
+): Promise<ImproveCategorizationOutput> {
+  const fallback = { success: true, message: '' };
+  return runWithAIFallback(improveCategorization, input, fallback, 'improveCategorization');
 }
 
 export async function handleVoiceCommandAction(

--- a/src/services/firebase-service.ts
+++ b/src/services/firebase-service.ts
@@ -1,12 +1,13 @@
 import { doc, getDoc, setDoc, updateDoc, onSnapshot, type Unsubscribe } from "firebase/firestore";
 import { db } from "@/lib/firebase-config";
-import type { Product } from "@/lib/types";
+import type { Product, Category } from "@/lib/types";
 import { v4 as uuidv4 } from 'uuid';
 
 export interface ListData {
   pantry: Product[];
   shoppingList: Product[];
   history: string[];
+  categoryOverrides: Record<string, Category>;
 }
 
 const listsCollection = "lists";
@@ -15,6 +16,7 @@ const emptyList: ListData = {
   pantry: [],
   shoppingList: [],
   history: [],
+  categoryOverrides: {},
 };
 
 export const sanitizeProductArray = (products: any): Product[] => {
@@ -74,6 +76,7 @@ export async function getOrCreateList(listId: string): Promise<ListData> {
         pantry: sanitizeProductArray(data.pantry),
         shoppingList: sanitizeProductArray(data.shoppingList),
         history: Array.isArray(data.history) ? data.history : [],
+        categoryOverrides: typeof data.categoryOverrides === 'object' ? data.categoryOverrides : {},
       };
     } else {
       // Do not create the document automatically when empty
@@ -122,6 +125,10 @@ export async function updateList(
       sanitizedData.history = rest.history;
     }
 
+    if (rest.categoryOverrides !== undefined) {
+      sanitizedData.categoryOverrides = rest.categoryOverrides;
+    }
+
     if (Object.keys(sanitizedData).length === 0) {
       return;
     }
@@ -159,6 +166,7 @@ export function onListUpdate(listId: string, callback: (data: ListData) => void)
         pantry: sanitizeProductArray(data.pantry),
         shoppingList: sanitizeProductArray(data.shoppingList),
         history: Array.isArray(data.history) ? data.history : [],
+        categoryOverrides: typeof data.categoryOverrides === 'object' ? data.categoryOverrides : {},
       });
     } else {
       callback({ ...emptyList });


### PR DESCRIPTION
## Summary
- save user category overrides in Firestore
- reuse saved categories when adding items
- update category when renaming items
- expose improveCategorization AI flow
- document the new feature in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing `@types/uuid`)*

------
https://chatgpt.com/codex/tasks/task_e_686c4f8fa7d08329b8b1d7933f7df9bb