### PR TITLE
refactor to client helpers

### DIFF
--- a/src/components/identify-products-dialog.tsx
+++ b/src/components/identify-products-dialog.tsx
@@ -5,7 +5,7 @@ import { useState, useRef, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useReponToast } from "@/hooks/use-repon-toast";
-import { identifyProductsFromPhotoAction } from "@/lib/actions";
+import { identifyProductsFromPhoto } from "@/lib/actions";
 import { Camera, Upload, Check, Loader2, RefreshCw } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
@@ -41,7 +41,7 @@ export function IdentifyProductsDialog({ open, onOpenChange, onAddProducts }: Id
   const handleIdentify = async (dataUri: string) => {
     setDialogState("processing");
     try {
-      const result = await identifyProductsFromPhotoAction({ photoDataUri: dataUri });
+      const result = await identifyProductsFromPhoto({ photoDataUri: dataUri });
       if (result.products.length > 0) {
         await (onAddProducts as any)(result.products);
         toast({ title: "Productos añadidos", description: `${result.products.length} producto(s) añadido(s) a tu despensa.` });

--- a/src/components/pantry-page.tsx
+++ b/src/components/pantry-page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
-import { generateRecipeAction, generateGrammaticalMessageAction, correctProductNameAction, improveCategorizationAction } from "@/lib/actions";
+import { generateRecipe, generateGrammaticalMessage, correctProductName, improveCategorization } from "@/lib/actions";
 import { type Product, type Category, type ProductStatus, type ViewMode, type GenerateRecipeOutput } from "@/lib/types";
 import { useReponToast } from "@/hooks/use-repon-toast";
 import { useSharedList } from "@/hooks/use-shared-list";
@@ -541,7 +541,7 @@ export default function PantryPage({ listId }: { listId: string }) {
     const toastie = toast({ title: "Actualizando nombre...", duration: 5000 });
 
     try {
-        const { correctedName } = await correctProductNameAction({ productName: finalNewName });
+        const { correctedName } = await correctProductName({ productName: finalNewName });
         
         const oldName = editingProduct.name;
         
@@ -777,7 +777,7 @@ export default function PantryPage({ listId }: { listId: string }) {
         const newOverrides = { ...categoryOverrides, [key]: newCategory };
         updateRemoteList({ pantry: newPantry, shoppingList: newShoppingList, categoryOverrides: newOverrides });
         try {
-            await improveCategorizationAction({ productName, userSelectedCategory: newCategory });
+            await improveCategorization({ productName, userSelectedCategory: newCategory });
         } catch (e) {
             console.warn('Failed to improve categorization', e);
         }
@@ -842,7 +842,7 @@ export default function PantryPage({ listId }: { listId: string }) {
 
     updateRemoteList({ pantry: newPantry, shoppingList: newShoppingList });
     if (!silent) {
-      const { message } = await generateGrammaticalMessageAction({ productName: boughtItem.name, messageType: 'added_to_pantry' });
+      const { message } = await generateGrammaticalMessage({ productName: boughtItem.name, messageType: 'added_to_pantry' });
       toast({ title: '¡A la saca!', description: message, audioText: message });
     }
   };
@@ -888,7 +888,7 @@ export default function PantryPage({ listId }: { listId: string }) {
     const newPantry = pantry.map(p => p.id === id ? { ...p, isPendingPurchase: true } : p);
     updateRemoteList({ pantry: newPantry, shoppingList: newShoppingList });
 
-    const { message } = await generateGrammaticalMessageAction({ productName: product.name, messageType: 'added_to_shopping_list' });
+    const { message } = await generateGrammaticalMessage({ productName: product.name, messageType: 'added_to_shopping_list' });
     toast({ title: '¡Anotado!', description: message, audioText: message });
   };
 
@@ -945,7 +945,7 @@ export default function PantryPage({ listId }: { listId: string }) {
     setIsRecipeDialogOpen(true);
 
     try {
-      const result = await generateRecipeAction({
+      const result = await generateRecipe({
         products: availableProducts
       });
       setRecipe(result);

--- a/src/hooks/use-shared-list.ts
+++ b/src/hooks/use-shared-list.ts
@@ -7,8 +7,8 @@ import { updateList, type ListData, sanitizeProductArray } from "@/services/fire
 import { type Product, type Category } from "@/lib/types";
 import { v4 as uuidv4 } from 'uuid';
 import {
-  categorizeProductAction,
-  correctProductNameAction,
+  categorizeProduct,
+  correctProductName,
 } from "@/lib/actions";
 import type { Toast } from "@/hooks/use-toast";
 
@@ -106,7 +106,7 @@ export function useSharedList(listId: string | null, toast: ToastFn) {
 
       const correctedNamesMap = new Map<string, string>();
       for (const name of names) {
-        const { correctedName } = await correctProductNameAction({ productName: name });
+        const { correctedName } = await correctProductName({ productName: name });
         correctedNamesMap.set(name, correctedName);
       }
 
@@ -129,7 +129,7 @@ export function useSharedList(listId: string | null, toast: ToastFn) {
           const overrideCat = listData.categoryOverrides[lower];
           const { category } = overrideCat
             ? { category: overrideCat }
-            : await categorizeProductAction({ productName: name });
+            : await categorizeProduct({ productName: name });
           return {
             id: uuidv4(),
             name,
@@ -184,7 +184,7 @@ export function useSharedList(listId: string | null, toast: ToastFn) {
 
       const productsToCreate: { name: string }[] = [];
 
-      const correctedNames = await Promise.all(names.map((name) => correctProductNameAction({ productName: name })));
+      const correctedNames = await Promise.all(names.map((name) => correctProductName({ productName: name })));
       const uniqueCorrectedNames = [
         ...new Map(correctedNames.map((item) => [item.correctedName.toLowerCase(), item.correctedName])).values(),
       ];
@@ -210,7 +210,7 @@ export function useSharedList(listId: string | null, toast: ToastFn) {
           const overrideCat = listData.categoryOverrides[lower];
           const { category } = overrideCat
             ? { category: overrideCat }
-            : await categorizeProductAction({ productName: product.name });
+            : await categorizeProduct({ productName: product.name });
           return {
             id: uuidv4(),
             name: product.name,

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,53 +1,53 @@
 
-"use server";
+
 
 import {
-  categorizeProduct,
+  categorizeProduct as categorizeProductFlow,
   type CategorizeProductInput,
   type CategorizeProductOutput,
 } from "@/ai/flows/categorize-product";
 import {
-  refineCategory,
+  refineCategory as refineCategoryFlow,
   type RefineCategoryInput,
   type RefineCategoryOutput,
 } from "@/ai/flows/refine-category";
 import {
-  improveCategorization,
+  improveCategorization as improveCategorizationFlow,
   type ImproveCategorizationInput,
   type ImproveCategorizationOutput,
 } from "@/ai/flows/improve-categorization";
 import {
-  handleVoiceCommand,
+  handleVoiceCommand as handleVoiceCommandFlow,
   type VoiceCommandInput,
   type VoiceCommandOutput,
 } from "@/ai/flows/voice-command-handler";
 import {
-  correctProductName,
+  correctProductName as correctProductNameFlow,
   type CorrectProductNameInput,
   type CorrectProductNameOutput,
 } from "@/ai/flows/correct-product-name";
 import { COMMON_PRODUCTS } from "@/data/common-products";
 import { levenshtein } from "@/lib/levenshtein";
 import {
-  identifyProductsFromPhoto,
+  identifyProductsFromPhoto as identifyProductsFromPhotoFlow,
   type IdentifyProductsFromPhotoInput,
   type IdentifyProductsFromPhotoOutput,
 } from '@/ai/flows/identify-products-from-photo';
 import {
-  textToSpeech,
+  textToSpeech as textToSpeechFlow,
   type TextToSpeechInput,
   type TextToSpeechOutput,
 } from "@/ai/flows/text-to-speech";
 
-import { generateGrammaticalMessage } from '@/ai/flows/generate-grammatical-message';
+import { generateGrammaticalMessage as generateGrammaticalMessageFlow } from '@/ai/flows/generate-grammatical-message';
 import type { GenerateGrammaticalMessageInput, GenerateGrammaticalMessageOutput } from '@/lib/types';
 import {
-  generateRecipe,
+  generateRecipe as generateRecipeFlow,
   type GenerateRecipeInput,
   type GenerateRecipeOutput,
 } from '@/ai/flows/generate-recipe';
 import {
-  conversationalAssistant,
+  conversationalAssistant as conversationalAssistantFlow,
   type AssistantInput,
   type AssistantOutput,
 } from '@/ai/flows/conversational-assistant';
@@ -72,37 +72,37 @@ async function runWithAIFallback<T, U>(
   }
 }
 
-export async function categorizeProductAction(
+export async function categorizeProduct(
   input: CategorizeProductInput
 ): Promise<CategorizeProductOutput> {
-  return runWithAIFallback(categorizeProduct, input, { category: 'Otros' }, 'categorizeProduct');
+  return runWithAIFallback(categorizeProductFlow, input, { category: 'Otros' }, 'categorizeProduct');
 }
 
-export async function refineCategoryAction(
+export async function refineCategory(
   input: RefineCategoryInput
 ): Promise<RefineCategoryOutput> {
   const fallback = { refinedCategory: input.userOverrideCategory };
-  return runWithAIFallback(refineCategory, input, fallback, 'refineCategory');
+  return runWithAIFallback(refineCategoryFlow, input, fallback, 'refineCategory');
 }
 
-export async function improveCategorizationAction(
+export async function improveCategorization(
   input: ImproveCategorizationInput
 ): Promise<ImproveCategorizationOutput> {
   const fallback = { success: true, message: '' };
-  return runWithAIFallback(improveCategorization, input, fallback, 'improveCategorization');
+  return runWithAIFallback(improveCategorizationFlow, input, fallback, 'improveCategorization');
 }
 
-export async function handleVoiceCommandAction(
+export async function handleVoiceCommand(
   input: VoiceCommandInput
 ): Promise<VoiceCommandOutput> {
   const fallback = {
     operations: [],
     response: 'No he podido procesar el comando de voz en este momento.',
   };
-  return runWithAIFallback(handleVoiceCommand, input, fallback, 'handleVoiceCommand');
+  return runWithAIFallback(handleVoiceCommandFlow, input, fallback, 'handleVoiceCommand');
 }
 
-export async function correctProductNameAction(
+export async function correctProductName(
   input: CorrectProductNameInput
 ): Promise<CorrectProductNameOutput> {
   const correctedName =
@@ -120,21 +120,21 @@ export async function correctProductNameAction(
   if (bestMatch.dist <= 2) {
     fallback = { correctedName: bestMatch.name };
   }
-  return runWithAIFallback(correctProductName, input, fallback, 'correctProductName');
+  return runWithAIFallback(correctProductNameFlow, input, fallback, 'correctProductName');
 }
 
-export async function identifyProductsFromPhotoAction(
+export async function identifyProductsFromPhoto(
   input: IdentifyProductsFromPhotoInput
 ): Promise<IdentifyProductsFromPhotoOutput> {
-  return runWithAIFallback(identifyProductsFromPhoto, input, { products: [] }, 'identifyProductsFromPhoto');
+  return runWithAIFallback(identifyProductsFromPhotoFlow, input, { products: [] }, 'identifyProductsFromPhoto');
 }
 
-export async function textToSpeechAction(input: TextToSpeechInput): Promise<TextToSpeechOutput> {
-    return runWithAIFallback(textToSpeech, input, { audioDataUri: undefined }, 'textToSpeech');
+export async function textToSpeech(input: TextToSpeechInput): Promise<TextToSpeechOutput> {
+    return runWithAIFallback(textToSpeechFlow, input, { audioDataUri: undefined }, 'textToSpeech');
 }
 
 
-export async function generateGrammaticalMessageAction(
+export async function generateGrammaticalMessage(
   input: GenerateGrammaticalMessageInput
 ): Promise<GenerateGrammaticalMessageOutput> {
     let fallbackMessage = "";
@@ -147,10 +147,10 @@ export async function generateGrammaticalMessageAction(
         case 'added_to_pantry': fallbackMessage = `"${input.productName}" se ha añadido a la despensa.`; break;
         case 'available': fallbackMessage = `"${input.productName}" ahora está disponible.`; break;
     }
-    return runWithAIFallback(generateGrammaticalMessage, input, { message: fallbackMessage }, 'generateGrammaticalMessage');
+    return runWithAIFallback(generateGrammaticalMessageFlow, input, { message: fallbackMessage }, 'generateGrammaticalMessage');
 }
 
-export async function generateRecipeAction(
+export async function generateRecipe(
   input: GenerateRecipeInput
 ): Promise<GenerateRecipeOutput> {
   const fallback = {
@@ -161,10 +161,10 @@ export async function generateRecipeAction(
     ],
     note: 'El servicio de IA no está disponible en este momento. Por favor, inténtelo de nuevo más tarde.',
   };
-  return runWithAIFallback(generateRecipe, input, fallback, 'generateRecipe');
+  return runWithAIFallback(generateRecipeFlow, input, fallback, 'generateRecipe');
 }
 
-export async function conversationalAssistantAction(
+export async function conversationalAssistant(
   input: AssistantInput
 ): Promise<AssistantOutput> {
   const fallback = {
@@ -173,6 +173,6 @@ export async function conversationalAssistantAction(
     operations: [],
     uiActions: [],
   };
-  return runWithAIFallback(conversationalAssistant, input, fallback, 'conversationalAssistant');
+  return runWithAIFallback(conversationalAssistantFlow, input, fallback, 'conversationalAssistant');
 }
 

--- a/src/providers/audio-provider.tsx
+++ b/src/providers/audio-provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
-import { textToSpeechAction } from '@/lib/actions';
+import { textToSpeech } from '@/lib/actions';
 
 interface AudioContextType {
   isAudioEnabled: boolean;
@@ -136,7 +136,7 @@ export function AudioProvider({ children }: { children: React.ReactNode }) {
       };
       
       try {
-        const result = await textToSpeechAction({ text });
+        const result = await textToSpeech({ text });
         const audioDataUri = result?.audioDataUri;
         
         if (!audioDataUri || !audioContextRef.current) {


### PR DESCRIPTION
## Summary
- remove server directive from `src/lib/actions.ts`
- alias AI flow imports and export client-friendly helpers
- update imports in components and hooks to use the new helpers

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68791c6f9e008329bf216d68c967f6c7