### PR TITLE
Add deterministic product categorization and migration tools

### DIFF
--- a/src/app/api/reclassify-others/route.ts
+++ b/src/app/api/reclassify-others/route.ts
@@ -1,0 +1,218 @@
+import { NextResponse } from "next/server";
+import { getApps, initializeApp, applicationDefault } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+import { categorizeProduct, type CategorizeProductSource } from "@/lib/actions";
+import {
+  ensureValidCategory,
+  isValidCategory,
+  normalizeForCategorization,
+} from "@/lib/categorization/localRules";
+import type { Category } from "@/lib/types";
+
+const DEFAULT_LIST_ID = "nuestra-despensa-compartida";
+
+interface ReclassifyRequestBody {
+  listId?: string;
+}
+
+interface ReclassifyUpdate {
+  id: string;
+  name: string;
+  previousCategory: Category;
+  newCategory: Category;
+  source: CategorizeProductSource;
+  collection: "pantry" | "shoppingList";
+}
+
+interface ReclassifySummary {
+  totalCandidates: number;
+  updated: number;
+  overridesAdded: number;
+  bySource: Record<CategorizeProductSource, number>;
+  updates: ReclassifyUpdate[];
+}
+
+type ProductLike = {
+  id?: string;
+  name?: unknown;
+  category?: unknown;
+  [key: string]: unknown;
+};
+
+function parseRequestBody(value: unknown): ReclassifyRequestBody {
+  if (typeof value !== "object" || value === null) {
+    return {};
+  }
+  return value as ReclassifyRequestBody;
+}
+
+function extractListId(body: ReclassifyRequestBody): string {
+  const requested = typeof body.listId === "string" ? body.listId.trim() : "";
+  return requested || DEFAULT_LIST_ID;
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = parseRequestBody(await req.json().catch(() => ({})));
+    const listId = extractListId(body);
+
+    if (getApps().length === 0) {
+      initializeApp({ credential: applicationDefault() });
+    }
+
+    const db = getFirestore();
+    const docRef = db.collection("lists").doc(listId);
+    const snap = await docRef.get();
+
+    if (!snap.exists) {
+      return NextResponse.json(
+        { error: `La lista "${listId}" no existe.` },
+        { status: 404 }
+      );
+    }
+
+    const data = snap.data() ?? {};
+    const pantry = Array.isArray(data.pantry) ? ([...data.pantry] as ProductLike[]) : [];
+    const shoppingList = Array.isArray(data.shoppingList)
+      ? ([...data.shoppingList] as ProductLike[])
+      : [];
+
+    const rawOverrides =
+      typeof data.categoryOverrides === "object" && data.categoryOverrides !== null
+        ? (data.categoryOverrides as Record<string, unknown>)
+        : {};
+
+    const normalizedOverrides: Record<string, Category> = {};
+    let overridesChanged = false;
+
+    for (const [key, value] of Object.entries(rawOverrides)) {
+      const categoryValue = typeof value === "string" ? value : undefined;
+      if (!isValidCategory(categoryValue)) {
+        overridesChanged = true;
+        continue;
+      }
+      if (categoryValue === "Otros") {
+        overridesChanged = true;
+        continue;
+      }
+      const normalizedKey = normalizeForCategorization(key);
+      if (normalizedKey !== key) {
+        overridesChanged = true;
+      }
+      normalizedOverrides[normalizedKey] = categoryValue as Category;
+    }
+
+    const summary: ReclassifySummary = {
+      totalCandidates: 0,
+      updated: 0,
+      overridesAdded: 0,
+      bySource: {
+        override: 0,
+        local: 0,
+        ai: 0,
+        fallback: 0,
+      },
+      updates: [],
+    };
+
+    let pantryChanged = false;
+    let shoppingListChanged = false;
+
+    const processItem = async (item: ProductLike, collection: "pantry" | "shoppingList") => {
+      if (!item || typeof item !== "object") {
+        return;
+      }
+      const name = typeof item.name === "string" ? item.name : "";
+      const currentCategoryRaw = typeof item.category === "string" ? item.category : "Otros";
+      const currentCategory = ensureValidCategory(currentCategoryRaw);
+
+      if (currentCategory !== "Otros" || !name.trim()) {
+        return;
+      }
+
+      summary.totalCandidates += 1;
+
+      const normalizedKey = normalizeForCategorization(name);
+      const legacyKey = name.toLowerCase();
+      const storedOverride = normalizedOverrides[normalizedKey] ?? normalizedOverrides[legacyKey];
+      const overrideForRun = storedOverride && storedOverride !== "Otros" ? storedOverride : undefined;
+
+      const { category, source } = await categorizeProduct({
+        productName: name,
+        overrideCategory: overrideForRun,
+      });
+
+      summary.bySource[source] += 1;
+
+      if (category !== currentCategory) {
+        item.category = category;
+        summary.updated += 1;
+        summary.updates.push({
+          id: typeof item.id === "string" ? item.id : "",
+          name,
+          previousCategory: currentCategory,
+          newCategory: category,
+          source,
+          collection,
+        });
+        if (collection === "pantry") {
+          pantryChanged = true;
+        } else {
+          shoppingListChanged = true;
+        }
+      }
+
+      if ((source === "local" || source === "ai") && category !== "Otros") {
+        if (normalizedOverrides[normalizedKey] !== category) {
+          normalizedOverrides[normalizedKey] = category;
+          summary.overridesAdded += 1;
+          overridesChanged = true;
+        }
+        if (legacyKey !== normalizedKey && normalizedOverrides[legacyKey]) {
+          delete normalizedOverrides[legacyKey];
+          overridesChanged = true;
+        }
+      }
+    };
+
+    for (const item of pantry) {
+      await processItem(item, "pantry");
+    }
+
+    for (const item of shoppingList) {
+      await processItem(item, "shoppingList");
+    }
+
+    if (!pantryChanged && !shoppingListChanged && !overridesChanged) {
+      return NextResponse.json({
+        message: "No se encontraron productos en 'Otros' para reclasificar.",
+        summary,
+      });
+    }
+
+    const payload: Record<string, unknown> = {};
+    if (pantryChanged) {
+      payload.pantry = pantry;
+    }
+    if (shoppingListChanged) {
+      payload.shoppingList = shoppingList;
+    }
+    if (overridesChanged) {
+      payload.categoryOverrides = normalizedOverrides;
+    }
+
+    await docRef.set(payload, { merge: true });
+
+    return NextResponse.json({
+      message: "Reclasificación completada.",
+      summary,
+    });
+  } catch (error) {
+    console.error("[RECLASSIFY-OTHERS] Error al reclasificar productos", error);
+    return NextResponse.json(
+      { error: "Error interno al reclasificar los productos." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/categorization/localRules.ts
+++ b/src/lib/categorization/localRules.ts
@@ -1,0 +1,400 @@
+import type { Category } from "@/lib/types";
+
+export const VALID_CATEGORIES: Category[] = [
+  "Frutas y Verduras",
+  "Lácteos y Huevos",
+  "Proteínas",
+  "Panadería y Cereales",
+  "Aperitivos",
+  "Bebidas",
+  "Hogar y Limpieza",
+  "Condimentos y Especias",
+  "Conservas y Despensa",
+  "Otros"
+];
+
+const CATEGORY_KEYWORDS: Record<Category, string[]> = {
+  "Frutas y Verduras": [
+    "manzana",
+    "pera",
+    "platano",
+    "banana",
+    "naranja",
+    "limon",
+    "mandarina",
+    "fresa",
+    "frambuesa",
+    "mora",
+    "uva",
+    "melocoton",
+    "albaricoque",
+    "cereza",
+    "sandia",
+    "melon",
+    "kiwi",
+    "mango",
+    "papaya",
+    "aguacate",
+    "tomate",
+    "lechuga",
+    "espinaca",
+    "acelga",
+    "col",
+    "coliflor",
+    "brocoli",
+    "calabacin",
+    "calabaza",
+    "pepino",
+    "zanahoria",
+    "pimiento",
+    "cebolla",
+    "ajo",
+    "patata",
+    "boniato",
+    "remolacha",
+    "berenjena",
+    "apio",
+    "seta",
+    "champinon",
+    "hongo",
+    "fruta",
+    "verdura",
+    "ensalada"
+  ],
+  "Lácteos y Huevos": [
+    "leche",
+    "yogur",
+    "yogurt",
+    "queso",
+    "mantequilla",
+    "margarina",
+    "nata",
+    "crema",
+    "requeson",
+    "cuajada",
+    "huevo",
+    "lacteo",
+    "kefir"
+  ],
+  "Proteínas": [
+    "pollo",
+    "pavo",
+    "cerdo",
+    "ternera",
+    "vacuno",
+    "buey",
+    "cordero",
+    "cabrito",
+    "conejo",
+    "carne",
+    "filete",
+    "bistec",
+    "solomillo",
+    "chuleta",
+    "costilla",
+    "lomo",
+    "embutido",
+    "jamon",
+    "salchicha",
+    "chorizo",
+    "mortadela",
+    "salami",
+    "hamburguesa",
+    "albondiga",
+    "tofu",
+    "seitan",
+    "tempeh",
+    "higado",
+    "pescado fresco",
+    "marisco",
+    "gamba",
+    "langostino",
+    "atun fresco",
+    "salmon",
+    "merluza"
+  ],
+  "Panadería y Cereales": [
+    "pan",
+    "baguette",
+    "barra",
+    "bolleria",
+    "croissant",
+    "magdalena",
+    "bizcocho",
+    "galleta",
+    "cereal",
+    "muesli",
+    "granola",
+    "avena",
+    "cuscus",
+    "quinoa",
+    "arroz",
+    "pasta",
+    "macarron",
+    "espagueti",
+    "fideo",
+    "lasana",
+    "masa",
+    "harina",
+    "maizena",
+    "maiz",
+    "trigo",
+    "centeno",
+    "integral",
+    "tortita",
+    "cacao",
+    "cacao en polvo",
+    "polvo de cacao",
+    "cacao puro",
+    "semilla",
+    "semilla de chia",
+    "semilla de lino",
+    "semilla de girasol",
+    "semilla de calabaza",
+    "semillas",
+    "gofio"
+  ],
+  "Aperitivos": [
+    "snack",
+    "aperitivo",
+    "patata frita",
+    "chips",
+    "nacho",
+    "palomita",
+    "fruto seco",
+    "cacahuete",
+    "almendra",
+    "pistacho",
+    "anacardo",
+    "nuez",
+    "mix de frutos",
+    "barrita",
+    "barrita energetica",
+    "regaliz",
+    "chuche",
+    "gominola"
+  ],
+  "Bebidas": [
+    "agua",
+    "refresco",
+    "cola",
+    "soda",
+    "zumo",
+    "jugo",
+    "bebida",
+    "cerveza",
+    "vino",
+    "cava",
+    "champan",
+    "sidra",
+    "licor",
+    "ron",
+    "whisky",
+    "vodka",
+    "te",
+    "infusion",
+    "manzanilla",
+    "poleo",
+    "tila",
+    "cafe",
+    "expreso",
+    "capuchino",
+    "batido",
+    "bebida vegetal",
+    "horchata"
+  ],
+  "Hogar y Limpieza": [
+    "lejia",
+    "limpiador",
+    "limpieza",
+    "detergente",
+    "suavizante",
+    "lavavajillas",
+    "jabon",
+    "gel",
+    "champu",
+    "acondicionador",
+    "ambientador",
+    "desodorante",
+    "esponja",
+    "estropajo",
+    "bayeta",
+    "trapo",
+    "fregona",
+    "escoba",
+    "cubo",
+    "guante",
+    "papel higienico",
+    "papel de cocina",
+    "servilleta",
+    "panuelo",
+    "papel aluminio",
+    "aluminio",
+    "film",
+    "plastico",
+    "bolsa basura",
+    "bolsa de basura",
+    "basura",
+    "bolsa reciclaje",
+    "reciclaje",
+    "insecticida",
+    "desinfectante",
+    "limpiacristales",
+    "multiusos",
+    "desengrasante",
+    "panal",
+    "higiene",
+    "higiene personal"
+  ],
+  "Condimentos y Especias": [
+    "aceite",
+    "vinagre",
+    "sal",
+    "pimienta",
+    "oregano",
+    "comino",
+    "curcuma",
+    "pimenton",
+    "hierba",
+    "especia",
+    "aderezo",
+    "mostaza",
+    "mayonesa",
+    "salsa",
+    "soja",
+    "barbacoa",
+    "ketchup",
+    "alioli",
+    "ajo en polvo",
+    "cebolla en polvo",
+    "caldo",
+    "pastilla",
+    "bouillon",
+    "laurel",
+    "canela",
+    "vainilla",
+    "nuez moscada",
+    "clavo",
+    "perejil",
+    "cilantro"
+  ],
+  "Conservas y Despensa": [
+    "conserva",
+    "lata",
+    "enlatado",
+    "tarro",
+    "bote",
+    "frasco",
+    "atun",
+    "sardina",
+    "mejillon",
+    "berberecho",
+    "caballa",
+    "anchoa",
+    "pulpo",
+    "calamar",
+    "almeja",
+    "maiz dulce",
+    "garbanzo",
+    "lenteja",
+    "alubia",
+    "judia",
+    "habichuela",
+    "tomate frito",
+    "tomate triturado",
+    "pure de tomate",
+    "pisto",
+    "mermelada",
+    "crema de cacahuete",
+    "miel",
+    "sirope",
+    "sopa instantanea",
+    "caldo en brick",
+    "leche condensada",
+    "leche evaporada",
+    "coco rallado",
+    "aceituna",
+    "alcaparra",
+    "pepinillo",
+    "brotes",
+    "brotes de soja",
+    "noodle",
+    "ramen",
+    "sazonador"
+  ],
+  "Otros": []
+};
+
+const keywordCategoryPairs: Array<{ keyword: string; category: Category }> = Object.entries(CATEGORY_KEYWORDS)
+  .flatMap(([category, keywords]) =>
+    keywords.map((keyword) => ({
+      keyword: normalizeForCategorization(keyword),
+      category: category as Category,
+    }))
+  )
+  .sort((a, b) => b.keyword.length - a.keyword.length);
+
+export type LocalCategorizationMatch = {
+  category: Category | null;
+  keyword?: string;
+  normalizedName: string;
+};
+
+export function normalizeForCategorization(value: string): string {
+  const withoutDiacritics = value
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "");
+
+  const singularized = withoutDiacritics
+    .split(/\s+/)
+    .map((word) => singularize(word))
+    .filter(Boolean)
+    .join(" ");
+
+  return singularized;
+}
+
+function singularize(word: string): string {
+  if (word.length <= 3) {
+    return word;
+  }
+
+  if (word.endsWith("ces")) {
+    return word.slice(0, -3) + "z";
+  }
+
+  if (word.endsWith("es") && word.length > 4) {
+    return word.slice(0, -2);
+  }
+
+  if (word.endsWith("s") && word.length > 3) {
+    return word.slice(0, -1);
+  }
+
+  return word;
+}
+
+export function categorizeWithLocalRules(name: string): LocalCategorizationMatch {
+  const normalizedName = normalizeForCategorization(name);
+
+  for (const { keyword, category } of keywordCategoryPairs) {
+    if (keyword && normalizedName.includes(keyword)) {
+      return { category, keyword, normalizedName };
+    }
+  }
+
+  return { category: null, normalizedName };
+}
+
+export function isValidCategory(value: string | null | undefined): value is Category {
+  if (!value) return false;
+  return VALID_CATEGORIES.includes(value as Category);
+}
+
+export function ensureValidCategory(value: string | null | undefined): Category {
+  return isValidCategory(value) ? (value as Category) : "Otros";
+}
+
+export const CATEGORY_KEYWORDS_MAP = CATEGORY_KEYWORDS;


### PR DESCRIPTION
## Summary
- add a local keyword-based categorization module and update the categorizer to return sources and prefer overrides and rules before AI
- normalize override keys across shared list operations and pantry UI updates to ensure consistent categorization handling
- expose a reclassification API endpoint and UI trigger to migrate existing "Otros" entries and persist overrides when local or AI rules succeed

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68dd8eda9d8c8329bbb38c4314b72c39